### PR TITLE
Move the kitten that's behind to the bottom

### DIFF
--- a/article/x-basics.html
+++ b/article/x-basics.html
@@ -159,7 +159,7 @@
         <p>
             The window on top, marked as <span class="code-literal">kitten1.png</span> in the inspector, owns
             a rectangle in the center of the screen. The window below, <span class="code-literal">kitten2.png</span>,
-            owns a "L" shape slightly above and to the left.
+            owns a "L" shape slightly below and to the left.
         </p>
         <p>
             When the X server needs pixels from a window, it tells the window to redraw the area it's missing

--- a/src/article-demos/x-basics.js
+++ b/src/article-demos/x-basics.js
@@ -183,7 +183,7 @@
 
         // The shaking window that's behind.
         var kitten2 = new DelayedExposeImage(server, "kitten2.png");
-        DemoCommon.centerWindow(display, kitten2.windowId, { x: -20, y: -40 });
+        DemoCommon.centerWindow(display, kitten2.windowId, { x: -20, y: 40 });
         display.mapWindow({ windowId: kitten2.windowId });
 
         // The window on top that's obscuring the window behind it.
@@ -273,7 +273,7 @@
 
         // The shaking window that's behind.
         var kitten2 = new DelayedExposeImage(server, "kitten2.png");
-        DemoCommon.centerWindow(display, kitten2.windowId, { x: -20, y: -40 });
+        DemoCommon.centerWindow(display, kitten2.windowId, { x: -20, y: 40 });
         display.mapWindow({ windowId: kitten2.windowId });
 
         // The circle window that's on top.


### PR DESCRIPTION
There's a slight amiguity in the text when it says refers to the
window "on top". With this change, it doesn't matter if "top" refers
to the z-axis or the y-axis; they're both the same kitten.

As a bonus, the "L" shape refered to is actually an "L", not an
upside down one :)
