### PR TITLE
Fix a typo in the article "composite"

### DIFF
--- a/article/composite.html
+++ b/article/composite.html
@@ -184,7 +184,7 @@
         </p>
         <p>
             The compositing manager has one job to do: draw the backing pixmaps of the windows together to form a
-            pretty picture as your output. Technically, the compositing manager could not draw any windows, or draw
+            pretty picture as your output. Technically, the compositing manager could draw any windows, or draw
             some windows more than once, or wobble them around or spin them on a cube, but unfortunately, there's no
             way for the compositing manager to influence how input is sent to individual windows, meaning that the
             compositing manager has no choice but to draw the windows so that they appear in the same place X thinks


### PR DESCRIPTION
My understanding is that the compositing manager _could_ apply any transformation to the backing pixmaps, but if we want the display to be coherent with the way X thinks of the window (and interact with it), we have to stick to basic rectangles. Does it make sense ? :)
