### PR TITLE
Fix typo in "Regional Geometry" article

### DIFF
--- a/article/regions.html
+++ b/article/regions.html
@@ -177,7 +177,7 @@
         <p>
             What we're going to do is walk over the walls of both bands at the same time, and then keep track of
             whether we're inside or outside of the corresponding band. When we transition from being outside both bands
-            to being inside both bands, or vice versa, we output a wall.
+            to being inside either band, or vice versa, we output a wall.
         </p>
         <pre><code class="js">function unionBands(bandA, bandB) {
     // The resulting band from the union.


### PR DESCRIPTION
I think for the union, the state transition when we output a wall is: "being outside both bands" = "not being inside either band" -> "being inside either band", as mentioned later in the article, in the "Implementing other operations" section.
