### PR TITLE
Fix typos

### DIFF
--- a/article/composite.html
+++ b/article/composite.html
@@ -212,7 +212,7 @@
             code</a>, both of which are valid options, but thankfully another X11 protocol extension can come to our rescue.
             The <a href="http://cgit.freedesktop.org/xorg/proto/renderproto/tree/renderproto.txt">X RENDER extension</a>
             provides a variety of advanced vector graphics for us, including matrix transforms, gradients, and, just for us,
-            alpha blending! It provides this through the (confusingly) named <span class="code-literal">Composite</span>
+            alpha blending! It provides this through the (confusingly named) <span class="code-literal">Composite</span>
             request, which does <span class="definition">alpha compositing</span> or blending of two images.
             Using this request to the X server instead of <span class="code-literal">CopyArea</span>, we can finally
             apply our hard-earned alpha and draw our windows semi-transparent.
@@ -231,7 +231,7 @@
         <section id="video-player">
         <h3>The intangible image</h3>
         <p>
-            I want to make you sure that you realize here that the image painted with COMPOSITE is really just whatever
+            I want to make sure that you realize here that the image painted with COMPOSITE is really just whatever
             the user wants it to be. This image doesn't actually get input: it just reacts to whatever else happens on
             screen. In order for input to make sense, however, the windows have to line up perfectly to whatever else
             is on the screen: much like in the "naive redirection" example above where the kitten just turned invisible,

--- a/article/rast1.html
+++ b/article/rast1.html
@@ -576,7 +576,7 @@ function blendPixel(imageData, x, y, src) {
             "being outside" much faster than how often the grid can change, or, at a "higher frequency".
         </p>
         <p>
-            ... Erm, that might also be too technical. Imagine a rectangle in our abstract grid that changes rapidly
+            ... Erm, that might also be too technical. Imagine a striped rectangle in our abstract grid that changes rapidly
             from black to white over and over again. Sampling this in our extremely course pixel grid will have a
             seemingly random pattern of sometimes white pixels and sometimes black pixels. This is known as a
             <a href="https://en.wikipedia.org/wiki/Moir%C3%A9_pattern" class="definition">moire pattern</a>,

--- a/article/rast2.html
+++ b/article/rast2.html
@@ -107,7 +107,7 @@ ctx.restore();
             Apple's Steve Jobs had met the Interpress engineers on his visit to PARC. Jobs thought that the printing business
             would be lucrative, and tried to simply buy Adobe outright. Instead, Adobe countered and instead sold a five-year
             license for PostScript to Apple. At the same time, Jobs and Apple were funding a small startup, Aldus, which was
-            making a WSYWIG app to create PostScript documents, "PageMaker". In early 1985, Apple released the first
+            making a WYSIWYG app to create PostScript documents, "PageMaker". In early 1985, Apple released the first
             PostScript-compliant printer, the Apple LaserWriter. The combination of the point-and-click Macintosh,
             PageMaker, and the LaserWriter singlehandedly turned the printing industry on its head, giving way to
             "desktop publishing" and solidifying PostScript its place in history. The main competition, Hewlett-Packard, would


### PR DESCRIPTION
- Taking out just confusingly out of that sentence results in "provides this through the name Composite request" which sounds... odd.
- You added a you word there.
- Clarifying that the rectangle is striped makes it more obvious that you're not talking about the rectangle flashing.
- "WSYWIG" is not a thing, as far as I'm aware and [Wikipedia doesn't list it either.](https://en.wikipedia.org/wiki/WYSIWYG#Related_acronyms) I assumed you meant WYSIWYG.

There's a dead link [right here](https://github.com/opl-/xplain/blob/92685b49f6f20a066040a54bda02c9858121b809/article/rast2.html#L214), but as I'm not sure if there is a better alternative than the Internet Archive I'll leave this one up to you.

That being said, thank you for writing these! The mix of history and showing practical examples is exactly how I like to teach and is so much better than just "it's like this because it is" that you sometimes get when trying to learn about things, so don't worry about the extended history you provided in `rast2.html`. Worst case people can just skip that section.